### PR TITLE
Fixes issue of hls-viewer being unable to directly open poll question from notification.

### DIFF
--- a/src/components/Footer/Widgets.jsx
+++ b/src/components/Footer/Widgets.jsx
@@ -16,6 +16,7 @@ import {
   useWidgetState,
 } from "../AppData/useUISettings";
 import { WIDGET_STATE, WIDGET_VIEWS } from "../../common/constants";
+import { useRecordingStreaming } from "@100mslive/react-sdk";
 
 export const Widgets = props => {
   const toggleWidget = useWidgetToggle();
@@ -23,6 +24,7 @@ export const Widgets = props => {
   const { showPolls } = useShowPolls();
   const { showWhiteboard } = useShowWhiteboard();
   const { showAudioShare } = useShowAudioShare();
+  const { isHLSRunning } = useRecordingStreaming();
 
   // const onClickShowPollData = () => {
   //   console.log("Show Poll Data");
@@ -30,8 +32,14 @@ export const Widgets = props => {
   // };
 
   const renderPollVoting = () => {
-    if (props.canShowPollWidget === true && widgetView === WIDGET_VIEWS.VOTE) {
-      return <Voting toggleVoting={toggleWidget} id={pollID} />;
+    if (widgetView === WIDGET_VIEWS.VOTE) {
+      if (isHLSRunning) {
+        if (props.canShowPollWidget) {
+          return <Voting toggleVoting={toggleWidget} id={pollID} />;
+        }
+      } else {
+        return <Voting toggleVoting={toggleWidget} id={pollID} />;
+      }
     }
   };
 
@@ -42,7 +50,7 @@ export const Widgets = props => {
         <Flex direction="column" css={{ p: "$10" }}>
           {(showWhiteboard || showAudioShare) && (
             <Flex css={{ gap: "$10", mb: "$12" }}>
-              {showAudioShare && <ScreenshareAudio/>}
+              {showAudioShare && <ScreenshareAudio />}
               {showWhiteboard && <ToggleWhiteboard />}
             </Flex>
           )}

--- a/src/components/Notifications/Notifications.jsx
+++ b/src/components/Notifications/Notifications.jsx
@@ -168,6 +168,8 @@ export function Notifications() {
       case HMSNotificationTypes.POLL_STARTED:
         if (notification.data.startedBy !== localPeerID) {
           hmsActions.setAppData("showPollWidget", false);
+
+          
           // ToastManager.addToast({
           //   title: `A poll was started: ${notification.data.title}`,
           //   action: (

--- a/src/components/Notifications/Notifications.jsx
+++ b/src/components/Notifications/Notifications.jsx
@@ -7,6 +7,7 @@ import {
   useHMSNotifications,
   useHMSStore,
   useHMSActions,
+  useRecordingStreaming,
 } from "@100mslive/react-sdk";
 import { Button } from "@100mslive/roomkit-react";
 import { ToastBatcher } from "../Toast/ToastBatcher";
@@ -38,6 +39,7 @@ export function Notifications() {
   const subscribedNotifications = useSubscribedNotifications() || {};
   const isHeadless = useIsHeadless();
   const toggleWidget = useWidgetToggle();
+  const { isHLSRunning } = useRecordingStreaming();
 
   useEffect(() => {
     if (!notification) {
@@ -167,26 +169,27 @@ export function Notifications() {
 
       case HMSNotificationTypes.POLL_STARTED:
         if (notification.data.startedBy !== localPeerID) {
-          hmsActions.setAppData("showPollWidget", false);
-
-          
-          // ToastManager.addToast({
-          //   title: `A poll was started: ${notification.data.title}`,
-          //   action: (
-          //     <Button
-          //       onClick={() => toggleWidget(notification.data.id)}
-          //       variant="standard"
-          //       css={{
-          //         backgroundColor: "$surface_bright",
-          //         fontWeight: "$semiBold",
-          //         color: "$on_surface_high",
-          //         p: "$xs $md",
-          //       }}
-          //     >
-          //       Vote
-          //     </Button>
-          //   ),
-          // });
+          if (isHLSRunning) {
+            hmsActions.setAppData("showPollWidget", false);
+          } else {
+            ToastManager.addToast({
+              title: `A poll was started: ${notification.data.title}`,
+              action: (
+                <Button
+                  onClick={() => toggleWidget(notification.data.id)}
+                  variant="standard"
+                  css={{
+                    backgroundColor: "$surface_bright",
+                    fontWeight: "$semiBold",
+                    color: "$on_surface_high",
+                    p: "$xs $md",
+                  }}
+                >
+                  Vote
+                </Button>
+              ),
+            });
+          }
         }
 
         break;

--- a/src/components/Polls/CreateQuestions/CreateQuestions.jsx
+++ b/src/components/Polls/CreateQuestions/CreateQuestions.jsx
@@ -5,7 +5,7 @@ import {
   selectPollByID,
   useHMSActions,
   useHMSStore,
-  useRecordingStreaming
+  useRecordingStreaming,
 } from "@100mslive/react-sdk";
 import { AddCircleIcon } from "@100mslive/react-icons";
 import { Button, Flex, Text } from "@100mslive/roomkit-react";
@@ -44,18 +44,18 @@ export function CreateQuestions() {
     await actions.interactivityCenter.startPoll(id);
 
     if (isHLSRunning) {
-    // Send Timed Metadata event for a Poll created only when HLS is running.
-    const data = { showPollWidget: true };
-    await actions.sendHLSTimedMetadata([
-      {
-        payload: JSON.stringify(data),
-        duration: 2,
-      },
-    ]);
-    console.log("Poll created and Timed Metadata sent");
-    console.log(data);
-    //Sets showPollWidget true for local peer
-    actions.setAppData("showPollWidget", true);
+      // Send Timed Metadata event for a Poll created only when HLS is running.
+      const data = { showPollWidget: true, pollID: id };
+      await actions.sendHLSTimedMetadata([
+        {
+          payload: JSON.stringify(data),
+          duration: 2,
+        },
+      ]);
+      console.log("Poll created and Timed Metadata sent");
+      console.log(data);
+      //Sets showPollWidget true for local peer
+      actions.setAppData("showPollWidget", true);
     }
 
     setWidgetView(WIDGET_VIEWS.VOTE);

--- a/src/components/Polls/CreateQuestions/CreateQuestions.jsx
+++ b/src/components/Polls/CreateQuestions/CreateQuestions.jsx
@@ -5,6 +5,7 @@ import {
   selectPollByID,
   useHMSActions,
   useHMSStore,
+  useRecordingStreaming
 } from "@100mslive/react-sdk";
 import { AddCircleIcon } from "@100mslive/react-icons";
 import { Button, Flex, Text } from "@100mslive/roomkit-react";
@@ -21,6 +22,7 @@ export function CreateQuestions() {
   const toggleWidget = useWidgetToggle();
   const { pollInView: id, setWidgetView } = useWidgetState();
   const interaction = useHMSStore(selectPollByID(id));
+  const { isHLSRunning } = useRecordingStreaming();
 
   const isValidPoll = useMemo(
     () =>
@@ -40,7 +42,9 @@ export function CreateQuestions() {
       }));
     await actions.interactivityCenter.addQuestionsToPoll(id, validQuestions);
     await actions.interactivityCenter.startPoll(id);
-    // Create a timed metadata event when a new poll is created.
+
+    if (isHLSRunning) {
+    // Send Timed Metadata event for a Poll created only when HLS is running.
     const data = { showPollWidget: true };
     await actions.sendHLSTimedMetadata([
       {
@@ -48,16 +52,11 @@ export function CreateQuestions() {
         duration: 2,
       },
     ]);
-
-    console.log("Timed Metadat sent");
+    console.log("Poll created and Timed Metadata sent");
     console.log(data);
-
     //Sets showPollWidget true for local peer
     actions.setAppData("showPollWidget", true);
-    // console.log("Set showPollWidget to false");
-
-    console.log("Timed Metadat sent");
-    console.log(data);
+    }
 
     setWidgetView(WIDGET_VIEWS.VOTE);
   };

--- a/src/layouts/HLSView.jsx
+++ b/src/layouts/HLSView.jsx
@@ -29,6 +29,7 @@ import { HLSAutoplayBlockedPrompt } from "../components/HMSVideo/HLSAutoplayBloc
 import { HLSQualitySelector } from "../components/HMSVideo/HLSQualitySelector";
 import { ToastManager } from "../components/Toast/ToastManager";
 import { APP_DATA, EMOJI_REACTION_TYPE } from "../common/constants";
+import { useWidgetToggle } from "../components/AppData/useSidepane";
 
 let hlsPlayer;
 
@@ -53,6 +54,7 @@ const HLSView = () => {
     onClose: () => toggle(false),
   });
   const [showLoader, setShowLoader] = useState(false);
+  const toggleWidget = useWidgetToggle();
 
   // FIXME: move this logic to player controller in next release
   useEffect(() => {
@@ -100,7 +102,24 @@ const HLSView = () => {
           duration: duration || 3000,
         };
         console.debug("Added toast ", JSON.stringify(toast));
-        ToastManager.addToast(toast);
+        ToastManager.addToast({
+          title: `A poll was started.`,
+          // ${notification.data.title}
+          action: (
+            <Button
+              onClick={() => toggleWidget(parsedPayload.pollID)}
+              variant="standard"
+              css={{
+                backgroundColor: "$surface_bright",
+                fontWeight: "$semiBold",
+                color: "$on_surface_high",
+                p: "$xs $md",
+              }}
+            >
+              Vote
+            </Button>
+          ),
+        });
       } else {
         switch (parsedPayload.type) {
           case EMOJI_REACTION_TYPE:

--- a/src/layouts/HLSView.jsx
+++ b/src/layouts/HLSView.jsx
@@ -104,7 +104,7 @@ const HLSView = () => {
 
           action: (
             <Button
-              onClick={() => toggleWidget(true)}
+              onClick={() => toggleWidget(parsedPayload.pollID)}
               variant="standard"
               css={{
                 backgroundColor: "$surface_bright",

--- a/src/layouts/HLSView.jsx
+++ b/src/layouts/HLSView.jsx
@@ -17,6 +17,7 @@ import {
   Box,
   Flex,
   IconButton,
+  Button,
   Loading,
   Text,
   Tooltip,
@@ -102,21 +103,18 @@ const HLSView = () => {
           // ${notification.data.title}
 
           action: (
-            <button onClick={() => toggleWidget(parsedPayload.pollID)}>
+            <Button
+              onClick={() => toggleWidget(true)}
+              variant="standard"
+              css={{
+                backgroundColor: "$surface_bright",
+                fontWeight: "$semiBold",
+                color: "$on_surface_high",
+                p: "$xs $md",
+              }}
+            >
               Vote
-            </button>
-            // <Button
-
-            //   variant="standard"
-            //   css={{
-            //     backgroundColor: "$surface_bright",
-            //     fontWeight: "$semiBold",
-            //     color: "$on_surface_high",
-            //     p: "$xs $md",
-            //   }}
-            // >
-
-            // </Button>
+            </Button>
           ),
         });
       } else {

--- a/src/layouts/HLSView.jsx
+++ b/src/layouts/HLSView.jsx
@@ -97,27 +97,26 @@ const HLSView = () => {
 
       if (parsedPayload.showPollWidget === true) {
         hmsActions.setAppData("showPollWidget", true);
-        const toast = {
-          title: `A new poll has started.`,
-          duration: duration || 3000,
-        };
-        console.debug("Added toast ", JSON.stringify(toast));
         ToastManager.addToast({
           title: `A poll was started.`,
           // ${notification.data.title}
+
           action: (
-            <Button
-              onClick={() => toggleWidget(parsedPayload.pollID)}
-              variant="standard"
-              css={{
-                backgroundColor: "$surface_bright",
-                fontWeight: "$semiBold",
-                color: "$on_surface_high",
-                p: "$xs $md",
-              }}
-            >
+            <button onClick={() => toggleWidget(parsedPayload.pollID)}>
               Vote
-            </Button>
+            </button>
+            // <Button
+
+            //   variant="standard"
+            //   css={{
+            //     backgroundColor: "$surface_bright",
+            //     fontWeight: "$semiBold",
+            //     color: "$on_surface_high",
+            //     p: "$xs $md",
+            //   }}
+            // >
+
+            // </Button>
           ),
         });
       } else {


### PR DESCRIPTION
Fixes:
- hls-viewer unable to directly open poll questions from notification.
- Polls not working when HLS is not running.

Still need to work on:
- hiding polls for all roles that aren't subscribed to them.
- persistence to be able to see older polls.
